### PR TITLE
[Feat] Implement Dashboard Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "dotenv": "^16.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.21.3",
+        "react-router-dom": "^6.22.0",
         "socket.io-client": "^4.7.4",
         "zustand": "^4.5.0"
       },
@@ -730,9 +730,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.2.tgz",
-      "integrity": "sha512-ACXpdMM9hmKZww21yEqWwiLws/UPLhNKvimN8RrYSqPSvB3ov7sLvAcfvaxePeLvccTQKGdkDIhLYApZVDFuKg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.0.tgz",
+      "integrity": "sha512-HOil5aFtme37dVQTB6M34G95kPM3MMuqSmIRVCC52eKV+Y/tGSqw9P3rWhlAx6A+mz+MoX+XxsGsNJbaI5qCgQ==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4669,11 +4669,11 @@
       "dev": true
     },
     "node_modules/react-router": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.3.tgz",
-      "integrity": "sha512-a0H638ZXULv1OdkmiK6s6itNhoy33ywxmUFT/xtSoVyf9VnC7n7+VT4LjVzdIHSaF5TIh9ylUgxMXksHTgGrKg==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.0.tgz",
+      "integrity": "sha512-q2yemJeg6gw/YixRlRnVx6IRJWZD6fonnfZhN1JIOhV2iJCPeRNSH3V1ISwHf+JWcESzLC3BOLD1T07tmO5dmg==",
       "dependencies": {
-        "@remix-run/router": "1.14.2"
+        "@remix-run/router": "1.15.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4683,12 +4683,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.3.tgz",
-      "integrity": "sha512-kNzubk7n4YHSrErzjLK72j0B5i969GsuCGazRl3G6j1zqZBLjuSlYBdVdkDOgzGdPIffUOc9nmgiadTEVoq91g==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.0.tgz",
+      "integrity": "sha512-z2w+M4tH5wlcLmH3BMMOMdrtrJ9T3oJJNsAlBJbwk+8Syxd5WFJ7J5dxMEW0/GEXD1BBis4uXRrNIz3mORr0ag==",
       "dependencies": {
-        "@remix-run/router": "1.14.2",
-        "react-router": "6.21.3"
+        "@remix-run/router": "1.15.0",
+        "react-router": "6.22.0"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dotenv": "^16.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.3",
+    "react-router-dom": "^6.22.0",
     "socket.io-client": "^4.7.4",
     "zustand": "^4.5.0"
   },

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,9 +1,17 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
+import { Routes, Route, useNavigate } from "react-router-dom";
+import Header from "./Header.jsx";
+
+import useUserStore from "../store/useUser.js";
+import Dashboard from "./Dashboard/index.jsx";
+import SingleComment from "./SingleComment/index.jsx";
+import Friends from "./Friends/index.jsx";
 
 function App() {
-  const [userData, setUserData] = useState(null);
+  const { setUserData } = useUserStore();
   const [loginCheck, setLoginCheck] = useState("loading");
+  const navigate = useNavigate();
 
   useEffect(() => {
     const token = new URLSearchParams(window.location.search).get("token");
@@ -22,6 +30,7 @@ function App() {
 
         setUserData(user);
         setLoginCheck("success");
+        navigate("/");
       } catch (error) {
         console.log("Login error:", error);
         setLoginCheck("fail");
@@ -44,9 +53,14 @@ function App() {
   }
 
   return (
-    <div className="font-bold m-80">
-      {userData ? `${userData.nickname}님이 로그인 하셨습니다.` : "not Login"}
-    </div>
+    <>
+      <Header />
+      <Routes>
+        <Route path="/" exact element={<Dashboard />} />
+        <Route path="/single" exact element={<SingleComment />} />
+        <Route path="/friend" exact element={<Friends />} />
+      </Routes>
+    </>
   );
 }
 

--- a/src/components/CommentCard/index.jsx
+++ b/src/components/CommentCard/index.jsx
@@ -1,8 +1,9 @@
-export default function CommentCard({ data }) {
-  const commentCreator = data.creator.nickname;
-  const commentText = data.text;
-  const commentPostDate = new Date(data.postDate);
-  const commentScreenshot = isValidBase64(data.screenshot);
+function CommentCard({ data }) {
+  const { creator, text, postDate, screenshot } = data;
+  const commentCreator = creator.nickname;
+  const commentText = text;
+  const commentPostDate = new Date(postDate);
+  const commentScreenshot = isValidBase64(screenshot);
   const formattedDate = formatDate(commentPostDate);
 
   return (
@@ -15,7 +16,7 @@ export default function CommentCard({ data }) {
       </div>
       <img
         className="w-full h-[130px] object-cover border-t"
-        src={`${commentScreenshot}`}
+        src={commentScreenshot}
         alt="Comment Screenshot"
       />
       <div className="p-2 text-gray-500 text-xs">{formattedDate}</div>
@@ -41,3 +42,5 @@ function isValidBase64(str) {
     return false;
   }
 }
+
+export default CommentCard;

--- a/src/components/CommentCard/index.jsx
+++ b/src/components/CommentCard/index.jsx
@@ -1,3 +1,6 @@
+import formatDate from "../../utils/formatDate";
+import isValidBase64 from "../../utils/decodeBase64";
+
 function CommentCard({ data }) {
   const { creator, text, postDate, screenshot } = data;
   const commentCreator = creator.nickname;
@@ -22,25 +25,6 @@ function CommentCard({ data }) {
       <div className="p-2 text-gray-500 text-xs">{formattedDate}</div>
     </div>
   );
-}
-
-function formatDate(date) {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-
-  return `${year}-${month}-${day} ${hours}:${minutes}`;
-}
-
-function isValidBase64(str) {
-  try {
-    return atob(str);
-  } catch (error) {
-    console.error(error);
-    return false;
-  }
 }
 
 export default CommentCard;

--- a/src/components/CommentCard/index.jsx
+++ b/src/components/CommentCard/index.jsx
@@ -1,0 +1,43 @@
+export default function CommentCard({ data }) {
+  const commentCreator = data.creator.nickname;
+  const commentText = data.text;
+  const commentPostDate = new Date(data.postDate);
+  const commentScreenshot = isValidBase64(data.screenshot);
+  const formattedDate = formatDate(commentPostDate);
+
+  return (
+    <div className="w-[150px] h-[220px] mt-4 ml-4 border rounded-md overflow-hidden shadow-md">
+      <div className="p-2 bg-black text-center text-[#38D431] font-bold text-sm">
+        {commentCreator}
+      </div>
+      <div className="whitespace-nowrap overflow-hidden overflow-ellipsis">
+        {commentText}
+      </div>
+      <img
+        className="w-full h-[130px] object-cover border-t"
+        src={`${commentScreenshot}`}
+        alt="Comment Screenshot"
+      />
+      <div className="p-2 text-gray-500 text-xs">{formattedDate}</div>
+    </div>
+  );
+}
+
+function formatDate(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+}
+
+function isValidBase64(str) {
+  try {
+    return atob(str);
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+}

--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -39,4 +39,5 @@ function Dashboard() {
     </div>
   );
 }
+
 export default Dashboard;

--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -1,0 +1,16 @@
+function Dashboard() {
+  return (
+    <div className="w-full h-full">
+      <button className="ml-[100px] mr-1 text-black text-2xl font-bold py-2 px-4 rounded">
+        My Comments
+      </button>
+      <span className="mr-1 text-black text-2xl font-bold py-2 px-4 rounded">
+        |
+      </span>
+      <button className="mr-1 text-black text-2xl font-bold py-2 px-4 rounded">
+        Received Comments
+      </button>
+    </div>
+  );
+}
+export default Dashboard;

--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -1,15 +1,41 @@
+import { useState } from "react";
+import useUserStore from "../../store/useUser";
+import CommentsCard from "../CommentCard";
+
 function Dashboard() {
+  const { userData } = useUserStore();
+  const [isMyComment, setIsMyComment] = useState(true);
+
+  const commentsList = isMyComment
+    ? userData.createdComments
+    : userData.receivedComments;
+
+  const listedComments = commentsList.map((comment) => {
+    return <CommentsCard key={comment._id} data={comment} />;
+  });
+
   return (
     <div className="w-full h-full">
-      <button className="ml-[100px] mr-1 text-black text-2xl font-bold py-2 px-4 rounded">
+      <button
+        onClick={() => setIsMyComment(true)}
+        className="ml-[100px] mr-1 text-black text-2xl font-bold py-2 px-4 rounded"
+      >
         My Comments
       </button>
       <span className="mr-1 text-black text-2xl font-bold py-2 px-4 rounded">
         |
       </span>
-      <button className="mr-1 text-black text-2xl font-bold py-2 px-4 rounded">
+      <button
+        onClick={() => setIsMyComment(false)}
+        className="mr-1 text-black text-2xl font-bold py-2 px-4 rounded"
+      >
         Received Comments
       </button>
+      <div className="flex w-full h-full justify-center mt-4">
+        <div className="flex justify-center w-11/12 h-[600px] border-8 border-black rounded-lg text-center">
+          {listedComments}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/Friends/index.jsx
+++ b/src/components/Friends/index.jsx
@@ -1,0 +1,5 @@
+function Friends() {
+  return <div>Friends 컴포넌트입니다.</div>;
+}
+
+export default Friends;

--- a/src/components/Header.jsx/index.jsx
+++ b/src/components/Header.jsx/index.jsx
@@ -1,0 +1,31 @@
+import { Link } from "react-router-dom";
+
+function Header() {
+  return (
+    <div className="bg-black py-[15px] pr-[20px] w-full h-[80px] flex border-solid border-2">
+      <Link to="/">
+        <button className="ml-[100px] mr-2 text-[#38D431] text-2xl font-bold py-2 px-4 rounded">
+          Dashboard
+        </button>
+      </Link>
+      <span className="ml-[5px] mr-2 text-[#38D431] text-2xl font-bold py-2 px-4 rounded">
+        |
+      </span>
+      <Link to="/single">
+        <button className=" ml-[5px] mr-2 text-[#38D431] text-2xl font-bold py-2 px-4 rounded">
+          Single Comment
+        </button>
+      </Link>
+      <span className="ml-[5px] mr-2 text-[#38D431] text-2xl font-bold py-2 px-4 rounded">
+        |
+      </span>
+      <Link to="/friend">
+        <button className=" ml-[5px] mr-2 text-[#38D431] text-2xl font-bold py-2 px-4 rounded">
+          friends
+        </button>
+      </Link>
+    </div>
+  );
+}
+
+export default Header;

--- a/src/components/SingleComment/index.jsx
+++ b/src/components/SingleComment/index.jsx
@@ -1,0 +1,4 @@
+function SingleComment() {
+  return <div>싱글커맨트 컴포넌트 입니다.</div>;
+}
+export default SingleComment;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,19 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+
 import App from "./components/App";
 import "./index.css";
 
+const router = createBrowserRouter([
+  {
+    path: "*",
+    element: <App />,
+  },
+]);
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
 );

--- a/src/store/useUser.js
+++ b/src/store/useUser.js
@@ -1,0 +1,8 @@
+import { create } from "zustand";
+
+const useUserStore = create((set) => ({
+  userData: null,
+  setUserData: (data) => set(() => ({ userData: data })),
+}));
+
+export default useUserStore;

--- a/src/utils/decodeBase64.js
+++ b/src/utils/decodeBase64.js
@@ -1,0 +1,10 @@
+function isValidBase64(str) {
+  try {
+    return atob(str);
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+}
+
+export default isValidBase64;

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -1,0 +1,11 @@
+function formatDate(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+}
+
+export default formatDate;


### PR DESCRIPTION
### itsComments

## [웹 Main 홈페이지 대시보드](https://boom-plant-4c9.notion.site/FE-Main-3b1391c973324803aa52d2add5f68f1b?pvs=4)

## Todo

- [x]  첫 메인페이지에는 대시보드 화면이보인다
- [x]  대시보드의 경우 내가 dashboard, sigle Comment, friend 버튼이있다.
- [x]  대시보드 페이지에는 내가만든 comments 내가 받은 comments 버튼이있다.
- [x]  내가 만든 comments 버튼 클릭시 내가 생성한 댓글들을 화면에 보여준다
- [x]  내가 받은 comments 버튼 클릭시 내가 받은 댓글들을 화면에 보여준다
- [ ]  comment를 클릭시 해당 commentid 링크로 이동한다(commentId페이지 구현후 진행)

## Description

- 로그인 후 대시보드 페이지 오픈
- 헤더컴포넌트 생성(헤더컴포넌트에서 버튼을 통해 페이지 이동)
- DashBoard 컴포넌트 내가 작성한 댓글과 내가 태그된 댓글로 구분
- 내가 작성한 댓글은 로그인 user의 createdComments 배열을 순회하면서 commentCard생성
- 내가 태그된 댓글은 로그인 user의 receivedComments 배열을 순회하면서 commentCard생성
- commentCard는 작성자(닉네임), 댓글내용, 스크린샷, 작성일자로 구성

## Concern(필요시)

- commentCard 클릭하여 해당 comment페이지로 이동의경우 commentId 구현후 진행

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
