### PR TITLE
[Feat] comment page navigation

### DIFF
--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
 import useUserStore from "../../store/useUser";
 import CommentCard from "../CommentCard";
-import { useNavigate } from "react-router-dom";
 
 function Dashboard() {
   const { userData } = useUserStore();
@@ -13,7 +14,6 @@ function Dashboard() {
     : userData.receivedComments;
 
   function navigateToCommentPage(commentId) {
-    console.log(commentId);
     navigate(`/comments/${commentId}`);
   }
 

--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -1,18 +1,27 @@
 import { useState } from "react";
 import useUserStore from "../../store/useUser";
 import CommentCard from "../CommentCard";
+import { useNavigate } from "react-router-dom";
 
 function Dashboard() {
   const { userData } = useUserStore();
   const [isMyComment, setIsMyComment] = useState(true);
+  const navigate = useNavigate();
 
   const commentsList = isMyComment
     ? userData.createdComments
     : userData.receivedComments;
 
-  const listedComments = commentsList.map((comment) => {
-    return <CommentCard key={comment._id} data={comment} />;
-  });
+  function navigateToCommentPage(commentId) {
+    console.log(commentId);
+    navigate(`/comments/${commentId}`);
+  }
+
+  const listedComments = commentsList.map((comment) => (
+    <div key={comment._id} onClick={() => navigateToCommentPage(comment._id)}>
+      <CommentCard data={comment} />
+    </div>
+  ));
 
   return (
     <div className="w-full h-full">

--- a/src/components/SingleView/index.jsx
+++ b/src/components/SingleView/index.jsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+
 import useUserStore from "../../store/useUser";
 import CommentCard from "../CommentCard";
-import { Link } from "react-router-dom";
 
 function SingleView() {
   const { createdComments, receivedComments } = useUserStore().userData;

--- a/src/components/SingleView/index.jsx
+++ b/src/components/SingleView/index.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import useUserStore from "../../store/useUser";
 import CommentCard from "../CommentCard";
+import { Link } from "react-router-dom";
 
 function SingleView() {
   const { createdComments, receivedComments } = useUserStore().userData;
@@ -28,9 +29,11 @@ function SingleView() {
             url로 이동
           </button>
         </a>
-        <button className="bg-blue-500 text-white ml-2 mt-1 mb-1 px-2 py-1 rounded hover:bg-blue-700">
-          댓글로 이동
-        </button>
+        <Link to={`/comments/${selectComment._id}`}>
+          <button className="bg-blue-500 text-white ml-2 mt-1 mb-1 px-2 py-1 rounded hover:bg-blue-700">
+            댓글로 이동
+          </button>
+        </Link>
         <img
           className="[w-700px] h-[600px] border-2 border-black rounded-lg"
           src={selectComment.screenshot}


### PR DESCRIPTION
### itsComments

## [[FE] 웹 Main 홈페이지 대시보드](https://boom-plant-4c9.notion.site/FE-Main-3b1391c973324803aa52d2add5f68f1b?pvs=4)
## [[FE] 웹 Main 홈페이지 Single view](https://boom-plant-4c9.notion.site/FE-Main-Single-view-b44715e0d7f34a068bf4989f56a3a45d?pvs=4)

## Todo

- [x]  comment를 클릭시 해당 commentid 링크로 이동한다
- [x]  댓글로이동 버튼 클릭시 해당 commentId페이지로 이동한다

## Description

- 대시보드 컴포넌트에서 커멘트카드 클릭시 해당 커멘트 페이지로 이동
- 대시보드의 경우 key값을 넣어야하기때문에 <div>를 추가해서 onClick이벤트에 navigate를 넣어서 커멘트카드 클릭시 이동
- 싱글뷰 컴포넌트에서 댓글로이동 버튼 클릭시 해당 커멘트 페이지로 이동
- 싱글뷰의 경우 버튼을 클릭해서 이동하기 때문에 버튼을 링크로 감싸서 버튼클릭시 이동

## Concern(필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
