### PR TITLE
[Feat] scroll to comment

### DIFF
--- a/src/components/FeedSingleComment/index.jsx
+++ b/src/components/FeedSingleComment/index.jsx
@@ -19,6 +19,13 @@ function FeedSingleComment() {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isModalOpen, setModalOpen] = useState(true);
   const [isReCommentOpen, setReComment] = useState(false);
+  const [scrollCoordinate, setScrollCoordinate] = useState(null);
+
+  useEffect(() => {
+    if (feedCommentData) {
+      setScrollCoordinate(parseInt(feedCommentData.postCoordinate.y, 10) - 200);
+    }
+  }, [feedCommentData]);
 
   const closeModal = () => {
     setModalOpen(false);
@@ -198,8 +205,7 @@ function FeedSingleComment() {
                   <p className="mt-4">{feedCommentData.text}</p>
                   <p className="text-xs text-gray-500">{commentDate}</p>
                   <a
-                    href={feedCommentData.postUrl}
-                    target="_blank"
+                    href={`${feedCommentData.postUrl}?scroll=${scrollCoordinate}`}
                     rel="noopener noreferrer"
                     className="text-xs text-blue-500 block overflow-hidden whitespace-nowrap overflow-ellipsis max-w-xs"
                   >

--- a/src/components/SingleView/index.jsx
+++ b/src/components/SingleView/index.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 
 import useCommentsStore from "../../store/useComments";
@@ -14,6 +14,13 @@ function SingleView() {
   }, [createdComments, receivedComments]);
 
   const [selectComment, setSelectComment] = useState(commentsList[0]);
+  const [scrollCoordinate, setScrollCoordinate] = useState(
+    parseInt(selectComment.postCoordinate.y, 10) - 200,
+  );
+
+  useEffect(() => {
+    setScrollCoordinate(parseInt(selectComment.postCoordinate.y, 10) - 200);
+  }, [selectComment]);
 
   const listedComments = commentsList.map((comment) => (
     <div key={comment._id} onClick={() => setSelectComment(comment)}>
@@ -35,7 +42,7 @@ function SingleView() {
           <div className="ml-[10px]">
             <p>작성자: {selectComment.creator.nickname}</p>
             <div>댓글내용: {selectComment.text}</div>
-            <a href={selectComment.postUrl}>
+            <a href={`${selectComment.postUrl}?scroll=${scrollCoordinate}`}>
               <button className="bg-green-500 text-white mt-1 mb-1 px-2 py-1 rounded hover:bg-green-700">
                 url로 이동
               </button>


### PR DESCRIPTION
### itsComments

## url이동시 해당 댓글로 이동하는 기능 구현

## Todo

- [x] 칸반 외 작업

## Description

- 싱글뷰, 커맨트페이지에서 url로 이동시 쿼리 매개변수를 담아서 이동
- 댓글의 postCoordinate.y값에서 문자열을 제외한 숫자로 변경
- 숫자로 변경된 값에서 200을 뺀값을 쿼리매개변수에 지정
- 200을 뺀이유는 빼지않으면 댓글이 최상단에 있기때문에 가시성을위해 200을 뺌

## Concern(필요시)

- 프론트에서 다른 도메인에 대한 권한이 없어서 익스텐션과 연동 작업진행하였습니다.
- 익스텐션에서 다른 새탭에서 실행하였을시 해당 탭에서 익스텐션이 바로 작동하지않기 때문에 새탭에서 이동이 아닌 현재탭에서 이동하였습니다.

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
